### PR TITLE
fix: handle pagination for PRs with many changed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,13 +58,23 @@ async function fetchContent(client, repoPath) {
 }
 
 async function getChangedFiles(client, prNumber) {
-  const listFilesResponse = await client.pulls.listFiles({
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    pull_number: prNumber,
-  });
+  const listFilesResponse = [];
+  let page = 1;
+  let response;
+  
+  do {
+    response = await client.pulls.listFiles({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page
+    });
+    listFilesResponse.push(...response.data);
+    page += 1;
+  } while (response.data.length)
 
-  const changedFiles = listFilesResponse.data.map((f) => f.filename);
+  const changedFiles = listFilesResponse.map((f) => f.filename);
 
   core.debug("found changed files:");
   for (const file of changedFiles) {


### PR DESCRIPTION
The GitHub API [actually returns a paginated list](https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files), with the length being 30 by default. I bump it up to 100 (the max) and query the API until the full list of changed files is obtained.

Discovered this issue when using this in my CI for a PR with 100+ files changed