### PR TITLE
Fix team reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ create configuration file
 ".github/**/*.yml":
   - foo
   - bar
+  
+# you can set team reviewers
+".github/**/*.md":
+  - team: baz
 ```
 
 Glob matching is based on the [minimatch library](https://github.com/isaacs/minimatch).

--- a/index.js
+++ b/index.js
@@ -97,14 +97,20 @@ function hasGlobPatternMatchedFile(changedFiles, globPattern) {
 
 async function assignReviewers(octokit, reviewers) {
   for (const reviewer of reviewers) {
+    await assignReviewer(octokit, reviewer);
+  }
+}
+
+async function assignReviewer(octokit, reviewer) {
+    const teamReviewer = reviewer.match(/^team:\s+?(.*?)$/);
+    const reviewerKey = teamReviewer ? "team_reviewers" : "reviewers";
+    const reviewerTarget = teamReviewer ? teamReviewer[1] : reviewer;
     await octokit.pulls.createReviewRequest({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      reviewers: [reviewer],
-      team_reviewers: [reviewer],
+      [reviewerKey]: [reviewerTarget],
     });
-  }
 }
 
 run();


### PR DESCRIPTION
I've been trying to use this action with `team_reviewers`, and it doesn't seem to work. If I have a team named `baz`, for example, I receive an error from GitHub: "Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the owner/repo repository."

I think this change would fix that. It introduces a "team:" prefix. If its set, it passes the value to `team_reviewers`, and if it isn't, it passes the value to `reviewers`.

I ran into troubles building this, so I wasn't able to test fully, but I tested that portion of the code, and tested the concept by making calls against the GitHub API.

Fixes #135 